### PR TITLE
Feature : 参数校验更规范版本的最小实现

### DIFF
--- a/src/main/java/com/byteblogs/common/base/domain/vo/BaseVO.java
+++ b/src/main/java/com/byteblogs/common/base/domain/vo/BaseVO.java
@@ -1,5 +1,7 @@
 package com.byteblogs.common.base.domain.vo;
 
+import com.byteblogs.common.validator.Messages;
+import com.byteblogs.common.validator.annotion.NotNull;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -15,6 +17,7 @@ public class BaseVO<T> {
     /**
      * 主键
      */
+    @NotNull(message = Messages.ID_NOT_NULL)
     protected Long id;
 
     /**

--- a/src/main/java/com/byteblogs/common/constant/Constants.java
+++ b/src/main/java/com/byteblogs/common/constant/Constants.java
@@ -59,4 +59,7 @@ public class Constants {
 
     public static final String BYTE_BLOGS_ADD_ARTICLE = Constants.BYTE_BLOGS_URL + "/api/blog/posts/hello-blog/v1/add";
 
+    //异常类型
+    public static final String DELIMITER_TO = "@";
+    public static final String DELIMITER_COLON = ":";
 }

--- a/src/main/java/com/byteblogs/common/exception/ApiInvalidParamException.java
+++ b/src/main/java/com/byteblogs/common/exception/ApiInvalidParamException.java
@@ -1,0 +1,27 @@
+package com.byteblogs.common.exception;
+
+/**
+ * 自定义异常类型是方便全局异常拦截器将参数异常拦截，做统一的Response响应编码.如(20,"Parameter Error")
+ *
+ * @author Andy Chen
+ * @date 9/30/19 1:31 PM
+ */
+public class ApiInvalidParamException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public ApiInvalidParamException() {
+        super();
+    }
+
+    public ApiInvalidParamException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ApiInvalidParamException(String message) {
+        super(message);
+    }
+
+    public ApiInvalidParamException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/byteblogs/common/handler/HandlerExceptionResolver.java
+++ b/src/main/java/com/byteblogs/common/handler/HandlerExceptionResolver.java
@@ -2,6 +2,7 @@ package com.byteblogs.common.handler;
 
 import com.byteblogs.common.base.domain.Result;
 import com.byteblogs.common.constant.ErrorConstants;
+import com.byteblogs.common.exception.ApiInvalidParamException;
 import com.byteblogs.common.exception.BusinessException;
 import com.byteblogs.common.util.ErrorMessageUtil;
 import com.byteblogs.common.util.JsonUtil;
@@ -32,7 +33,11 @@ public class HandlerExceptionResolver implements org.springframework.web.servlet
         // 组装错误提示信息
         String errorCode = exception instanceof BusinessException ? ((BusinessException) exception).getCode() : ErrorConstants.OPERATION_FAIL;
         String message = ErrorMessageUtil.getErrorMessage(errorCode, null);
-
+        if (exception instanceof ApiInvalidParamException) {
+            //定义错误编码
+            //errorCode = 10001;
+            message = exception.getMessage();
+        }
         // 响应类型设置
         response.setContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
 

--- a/src/main/java/com/byteblogs/common/util/ThrowableUtils.java
+++ b/src/main/java/com/byteblogs/common/util/ThrowableUtils.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  */
 public class ThrowableUtils {
     /**
-     * 校验参数正确
+     * 校验参数正确,拼装字段名和值到错误信息
      * @param result
      */
     public static void checkParamArgument(BindingResult result) {

--- a/src/main/java/com/byteblogs/common/util/ThrowableUtils.java
+++ b/src/main/java/com/byteblogs/common/util/ThrowableUtils.java
@@ -1,0 +1,48 @@
+package com.byteblogs.common.util;
+
+import cn.hutool.core.collection.CollectionUtil;
+import com.byteblogs.common.constant.Constants;
+import com.byteblogs.common.exception.ApiInvalidParamException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author Andy Chen
+ * @date 9/30/19 1:30 PM
+ */
+public class ThrowableUtils {
+    /**
+     * 校验参数正确
+     * @param result
+     */
+    public static void checkParamArgument(BindingResult result) {
+        if (result != null && result.hasErrors()) {
+            StringBuilder sb = new StringBuilder();
+            List<FieldError> errors = result.getFieldErrors();
+            if(CollectionUtil.isNotEmpty(errors)){
+                FieldError error = errors.get(0);
+                String rejectedValue = Objects.toString(error.getRejectedValue(), "");
+                String defMsg = error.getDefaultMessage();
+                //排除类上面的注解提示
+                if(rejectedValue.contains(Constants.DELIMITER_TO)){
+                    //自己去确定错误字段
+                    sb.append(defMsg);
+                }else{
+                    if(defMsg.contains(Constants.DELIMITER_COLON)){
+                        sb.append(error.getField()).append(" ").append(defMsg);
+                    }else{
+                        sb.append(error.getField()).append(" ").append(defMsg).append(":").append(rejectedValue);
+                    }
+                }
+            } else {
+                String msg = result.getAllErrors().get(0).getDefaultMessage();
+                sb.append(msg);
+            }
+            throw new ApiInvalidParamException(sb.toString());
+        }
+
+    }
+}

--- a/src/main/java/com/byteblogs/common/validator/Messages.java
+++ b/src/main/java/com/byteblogs/common/validator/Messages.java
@@ -1,0 +1,28 @@
+package com.byteblogs.common.validator;
+
+/**
+ * @author Andy Chen
+ * @date 9/30/19 12:46 PM
+ */
+public interface Messages {
+    /**
+     * 类内部使用
+     */
+    String CK_RANG_MESSAGE_LENGTH_TYPE = "length must be between 0 and 11:%s";
+    String CK_NUMERIC_TYPE = "field must be a number:%s";
+
+    /**
+     * 注解默认
+     */
+    String CK_NOT_BLANK_DEFAUL = "field can not be blank:{value}";
+    String CK_NUMERIC_DEFAUL = "field must be a number:{value}";
+    String CK_RANGE_DEFAUL = "field should be an integer,between {min} and {max}:{value}";
+
+    /**
+     * 注解使用
+     */
+    String CATEGORY_NAME_NOT_BLANK="name can not be blank:{value}";
+    String ID_NOT_NULL="id can not be null:{value}";
+
+}
+

--- a/src/main/java/com/byteblogs/common/validator/Messages.java
+++ b/src/main/java/com/byteblogs/common/validator/Messages.java
@@ -6,7 +6,7 @@ package com.byteblogs.common.validator;
  */
 public interface Messages {
     /**
-     * 类内部使用
+     * 类内部使用,自定义reject value
      */
     String CK_RANG_MESSAGE_LENGTH_TYPE = "length must be between 0 and 11:%s";
     String CK_NUMERIC_TYPE = "field must be a number:%s";
@@ -14,15 +14,9 @@ public interface Messages {
     /**
      * 注解默认
      */
-    String CK_NOT_BLANK_DEFAUL = "field can not be blank:{value}";
-    String CK_NUMERIC_DEFAUL = "field must be a number:{value}";
-    String CK_RANGE_DEFAUL = "field should be an integer,between {min} and {max}:{value}";
-
-    /**
-     * 注解使用
-     */
-    String CATEGORY_NAME_NOT_BLANK="name can not be blank:{value}";
-    String ID_NOT_NULL="id can not be null:{value}";
-
+    String CK_NOT_BLANK_DEFAUL = "can not be blank";
+    String CK_NUMERIC_DEFAUL = "must be a number";
+    String CK_RANGE_DEFAUL = "should be an integer,between {min} and {max}";
+    String ID_NOT_NULL="can not be null";
 }
 

--- a/src/main/java/com/byteblogs/common/validator/annotion/NotBlank.java
+++ b/src/main/java/com/byteblogs/common/validator/annotion/NotBlank.java
@@ -1,0 +1,32 @@
+package com.byteblogs.common.validator.annotion;
+
+import com.byteblogs.common.validator.Messages;
+import com.byteblogs.common.validator.constraint.StringValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * 不为空字符串
+ * @author Andy Chen
+ * @date 9/30/19 1:10 PM
+ */
+@Target({TYPE, ANNOTATION_TYPE,FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {StringValidator.class})
+public @interface NotBlank {
+    String message() default Messages.CK_NOT_BLANK_DEFAUL;
+
+    String value() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/byteblogs/common/validator/annotion/NotNull.java
+++ b/src/main/java/com/byteblogs/common/validator/annotion/NotNull.java
@@ -1,0 +1,33 @@
+package com.byteblogs.common.validator.annotion;
+
+import com.byteblogs.common.validator.constraint.IdValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ *  这里有些冗余了，其实面对控制器的VO对象，应该全为String类型。
+ *  作为后端程序员，不应该相信前端传递的任何参数，所以字符串类型也应该被识别。
+ * @author Andy Chen
+ * @date 9/30/19 1:24 PM
+ */
+@Target({TYPE, ANNOTATION_TYPE,FIELD,PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {IdValidator.class})
+public @interface NotNull {
+    String message() default "";
+
+    String value() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/byteblogs/common/validator/annotion/Numeric.java
+++ b/src/main/java/com/byteblogs/common/validator/annotion/Numeric.java
@@ -1,0 +1,35 @@
+package com.byteblogs.common.validator.annotion;
+
+import com.byteblogs.common.validator.Messages;
+import com.byteblogs.common.validator.constraint.NumericValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * 是否为数字
+ * 
+ * @author Andy Chen
+ * @date 9/30/19 12:33 PM
+ */
+@Target({TYPE, ANNOTATION_TYPE,FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {NumericValidator.class})
+public @interface Numeric {
+
+    String message() default Messages.CK_NUMERIC_DEFAUL;
+
+    String value() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/byteblogs/common/validator/annotion/Range.java
+++ b/src/main/java/com/byteblogs/common/validator/annotion/Range.java
@@ -1,0 +1,38 @@
+package com.byteblogs.common.validator.annotion;
+
+import com.byteblogs.common.validator.Messages;
+import com.byteblogs.common.validator.constraint.RangValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.TYPE;
+
+/**
+ * 数字的范围约束
+ * 
+ * @author Andy Chen
+ * @date 9/30/19 12:33 PM
+ */
+@Target({TYPE, ANNOTATION_TYPE,FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {RangValidator.class})
+public @interface Range {
+    long min() default 0;
+
+    long max() default Long.MAX_VALUE;
+
+    String message() default Messages.CK_RANGE_DEFAUL;
+
+    String value() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/byteblogs/common/validator/constraint/IdValidator.java
+++ b/src/main/java/com/byteblogs/common/validator/constraint/IdValidator.java
@@ -1,0 +1,23 @@
+package com.byteblogs.common.validator.constraint;
+
+import com.byteblogs.common.validator.annotion.NotNull;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * 这里有些冗余了，其实面对控制器的VO对象，应该全为String类型。
+ * 作为后端程序员，不应该相信前端传递的任何参数，所以字符串类型也应该被识别。然后使用{@link com.byteblogs.common.validator.annotion.Numeric}注解
+ *
+ * @author Andy Chen
+ * @date 9/30/19 1:24 PM
+ */
+public class IdValidator implements ConstraintValidator<NotNull, Long> {
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/byteblogs/common/validator/constraint/NumericValidator.java
+++ b/src/main/java/com/byteblogs/common/validator/constraint/NumericValidator.java
@@ -1,0 +1,24 @@
+package com.byteblogs.common.validator.constraint;
+
+import com.byteblogs.common.validator.annotion.Numeric;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * @author Andy Chen
+ * @date 9/30/19 12:33 PM
+ */
+public class NumericValidator implements ConstraintValidator<Numeric, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || StringUtils.isBlank(value)) {
+            return false;
+        }
+        if (!StringUtils.isNumeric(value)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/byteblogs/common/validator/constraint/RangValidator.java
+++ b/src/main/java/com/byteblogs/common/validator/constraint/RangValidator.java
@@ -1,0 +1,47 @@
+package com.byteblogs.common.validator.constraint;
+
+import com.byteblogs.common.validator.Messages;
+import com.byteblogs.common.validator.annotion.Range;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * @author Andy Chen
+ * @date 9/30/19 12:41 PM
+ */
+public class RangValidator implements ConstraintValidator<Range, String> {
+    private long min;
+    private long max;
+    private final int DEFAULT_MAX = 11;
+
+    @Override
+    public void initialize(Range constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (null == value || StringUtils.isBlank(value)) {
+            return false;
+        }
+        // 限制长度最大11
+        if (value.length() > DEFAULT_MAX) {
+            String template = String.format(Messages.CK_RANG_MESSAGE_LENGTH_TYPE, value);
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(template).addConstraintViolation();
+            return false;
+        }
+        // 是否可数字化
+        if (!StringUtils.isNumeric(value)) {
+            String template = String.format(Messages.CK_NUMERIC_TYPE, value);
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(template).addConstraintViolation();
+            return false;
+        }
+        long l = Long.parseLong(value);
+        return l >= min && l <= max;
+    }
+}

--- a/src/main/java/com/byteblogs/common/validator/constraint/StringValidator.java
+++ b/src/main/java/com/byteblogs/common/validator/constraint/StringValidator.java
@@ -1,0 +1,22 @@
+package com.byteblogs.common.validator.constraint;
+
+import com.byteblogs.common.validator.annotion.NotBlank;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * 不为空字符串
+ * @author Andy Chen
+ * @date 9/30/19 1:10 PM
+ */
+public class StringValidator implements ConstraintValidator<NotBlank, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || StringUtils.isBlank(value)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/byteblogs/helloblog/category/controller/CategoryController.java
+++ b/src/main/java/com/byteblogs/helloblog/category/controller/CategoryController.java
@@ -1,10 +1,9 @@
 package com.byteblogs.helloblog.category.controller;
 
-import com.byteblogs.common.annotation.LoginRequired;
-import com.byteblogs.common.base.domain.Result;
-import com.byteblogs.helloblog.category.domain.vo.CategoryVO;
-import com.byteblogs.helloblog.category.service.CategoryService;
+import com.byteblogs.common.validator.annotion.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,6 +12,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.byteblogs.common.annotation.LoginRequired;
+import com.byteblogs.common.base.domain.Result;
+import com.byteblogs.common.util.ThrowableUtils;
+import com.byteblogs.helloblog.category.domain.vo.CategoryVO;
+import com.byteblogs.helloblog.category.service.CategoryService;
 
 /**
  * @author byteblogs
@@ -27,42 +32,49 @@ public class CategoryController {
 
     @LoginRequired
     @PostMapping("/category/v1/add")
-    public Result saveCategory(@RequestBody CategoryVO categoryVO) {
+    public Result saveCategory(@Validated @RequestBody CategoryVO categoryVO, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.saveCategory(categoryVO);
     }
 
     @LoginRequired
     @PutMapping("/category/v1/update")
-    public Result updateCategory(@RequestBody CategoryVO categoryVO) {
+    public Result updateCategory(@Validated @RequestBody CategoryVO categoryVO, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.updateCategory(categoryVO);
     }
 
     @LoginRequired
     @GetMapping("/category-tags/v1/{id}")
-    public Result getCategoryTags(@PathVariable(value = "id", required = true) Long id) {
+    public Result getCategoryTags(@Validated @PathVariable(value = "id", required = true) @NotNull Long id, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.getCategoryTags(id);
     }
 
     @LoginRequired
     @GetMapping("/category-tags/v1/list")
-    public Result getCategoryTagsList(CategoryVO categoryVO) {
+    public Result getCategoryTagsList(@Validated CategoryVO categoryVO, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.getCategoryTagsList(categoryVO);
     }
 
 
     @GetMapping("/category/v1/{id}")
-    public Result getCategory(@PathVariable(value = "id", required = true) Long id) {
+    public Result getCategory(@Validated @PathVariable(value = "id", required = true) @NotNull Long id, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.getCategory(id);
     }
 
     @GetMapping("/category/v1/list")
-    public Result getCategoryList(CategoryVO categoryVO) {
+    public Result getCategoryList(@Validated CategoryVO categoryVO, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.getCategoryList(categoryVO);
     }
 
     @LoginRequired
     @DeleteMapping("/category/v1/{id}")
-    public Result deleteCategory(@PathVariable(value = "id", required = true) Long id) {
+    public Result deleteCategory(@Validated @PathVariable(value = "id", required = true) @NotNull Long id, BindingResult result) {
+        ThrowableUtils.checkParamArgument(result);
         return categoryService.deleteCategory(id);
     }
 

--- a/src/main/java/com/byteblogs/helloblog/category/domain/vo/CategoryVO.java
+++ b/src/main/java/com/byteblogs/helloblog/category/domain/vo/CategoryVO.java
@@ -1,6 +1,8 @@
 package com.byteblogs.helloblog.category.domain.vo;
 
 import com.byteblogs.common.base.domain.vo.BaseVO;
+import com.byteblogs.common.validator.Messages;
+import com.byteblogs.common.validator.annotion.NotBlank;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -18,6 +20,7 @@ public class CategoryVO extends BaseVO<CategoryVO> {
     /**
      * 名称
      */
+    @NotBlank(message = Messages.CATEGORY_NAME_NOT_BLANK)
     private String name;
 
     /**

--- a/src/main/java/com/byteblogs/helloblog/category/domain/vo/CategoryVO.java
+++ b/src/main/java/com/byteblogs/helloblog/category/domain/vo/CategoryVO.java
@@ -3,6 +3,7 @@ package com.byteblogs.helloblog.category.domain.vo;
 import com.byteblogs.common.base.domain.vo.BaseVO;
 import com.byteblogs.common.validator.Messages;
 import com.byteblogs.common.validator.annotion.NotBlank;
+import com.byteblogs.common.validator.annotion.Range;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -20,7 +21,7 @@ public class CategoryVO extends BaseVO<CategoryVO> {
     /**
      * 名称
      */
-    @NotBlank(message = Messages.CATEGORY_NAME_NOT_BLANK)
+    @NotBlank(message = Messages.CK_NOT_BLANK_DEFAUL)
     private String name;
 
     /**

--- a/src/main/java/com/byteblogs/helloblog/category/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/byteblogs/helloblog/category/service/impl/CategoryServiceImpl.java
@@ -18,7 +18,6 @@ import com.byteblogs.helloblog.category.domain.po.Tags;
 import com.byteblogs.helloblog.category.domain.vo.CategoryVO;
 import com.byteblogs.helloblog.category.domain.vo.TagsVO;
 import com.byteblogs.helloblog.category.service.CategoryService;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
@@ -52,10 +51,6 @@ public class CategoryServiceImpl extends ServiceImpl<CategoryDao, Category> impl
 
     @Override
     public Result saveCategory(CategoryVO categoryVO) {
-
-        if (categoryVO == null || StringUtils.isBlank(categoryVO.getName())) {
-            ExceptionUtil.rollback("保存分类失败", ErrorConstants.PARAM_INCORRECT);
-        }
 
         Category category = new Category().setName(categoryVO.getName()).setCreateTime(LocalDateTime.now()).setUpdateTime(LocalDateTime.now());
         this.categoryDao.insert(category);
@@ -128,9 +123,6 @@ public class CategoryServiceImpl extends ServiceImpl<CategoryDao, Category> impl
 
     @Override
     public Result getCategoryTags(Long id) {
-        if (id == null) {
-            ExceptionUtil.rollback(ErrorConstants.PARAM_INCORRECT);
-        }
 
         Category category = this.categoryDao.selectOne(new LambdaQueryWrapper<Category>().eq(Category::getId, id));
 
@@ -149,11 +141,6 @@ public class CategoryServiceImpl extends ServiceImpl<CategoryDao, Category> impl
 
     @Override
     public Result getCategory(Long id) {
-
-        if (id == null) {
-            ExceptionUtil.rollback(ErrorConstants.PARAM_INCORRECT);
-        }
-
         Category category = this.categoryDao.selectOne(new LambdaQueryWrapper<Category>().eq(Category::getId, id));
 
         List<CategoryTags> categoryTags = categoryTagsDao.selectList(new LambdaQueryWrapper<CategoryTags>().eq(CategoryTags::getCategoryId, category.getId()));
@@ -171,10 +158,6 @@ public class CategoryServiceImpl extends ServiceImpl<CategoryDao, Category> impl
 
     @Override
     public Result updateCategory(CategoryVO categoryVO) {
-
-        if (categoryVO == null || StringUtils.isBlank(categoryVO.getName()) || categoryVO.getId() == null) {
-            ExceptionUtil.rollback("保存分类失败", ErrorConstants.PARAM_INCORRECT);
-        }
 
         Category category1 = this.categoryDao.selectById(categoryVO.getId());
         if (category1 == null) {
@@ -204,10 +187,6 @@ public class CategoryServiceImpl extends ServiceImpl<CategoryDao, Category> impl
 
     @Override
     public Result deleteCategory(Long id) {
-
-        if (id == null) {
-            ExceptionUtil.rollback(ErrorConstants.PARAM_INCORRECT);
-        }
 
         this.categoryDao.deleteById(id);
         this.categoryTagsDao.delete(new LambdaQueryWrapper<CategoryTags>().eq(CategoryTags::getCategoryId, id));


### PR DESCRIPTION
## 参数校验应在控制器层处理
- spring 提供了 validation 参数校验框架,通过@Validated注解和BindingResult对象来校验参数的正确性（在控制器层）
- 在控制器层校验参数，使业务层的代码更加专注于业务而纯净。
- 提供了诸如字符串非空，是否数字，数字范围约束等普通的校验注解
- 后端应不相信前端传递的任何参数， 所以面对控制器的VO对象，数据类型应为String（int或long用@Numeric约束），以兼容前端传递的任何参数
- 提供了更加友好的异常返回信息,校验校验失败后,通过BindingResult对象和ThrowableUtils，会将字段名称和字段值拼接在异常信息中，以返回友好提示。

## 未实现的Feature
- 如果需要查询数据库以校验参数正确性时，也应在Validator中访问Redis(在编辑数据时，存入Redis，以提高校验速度)来校验参数的数据库有效性（Validator实现了ConstraintValidator接口，是一个被IOC管理的Bean，可通过@Autowired注解注入Bean）

## 发现的问题
- 后端返回的异常信息不规范,在“系统测试”时发现[JSON解析失败，未传递body]仍会返回非格式化信息给Request User.